### PR TITLE
Bonzo Network: Fix json being truncated by one byte

### DIFF
--- a/src/Network/Network_Mongoose.cpp
+++ b/src/Network/Network_Mongoose.cpp
@@ -203,8 +203,7 @@ namespace Network
 		// - verify size
 		// - non-ascii symbols ?
 		// - asynchronous update ?
-		data[size-1] = '\0'; // ensure we do have an end to the char string after "size" bytes
-		std::string TextJson = std::string((char*)data);
+		std::string TextJson = std::string((char*)data, size);
 		//printf("JSON: %s\n", TextJson.c_str());
 		jsonxx::Object NewShader;
     jsonxx::Object Data;


### PR DESCRIPTION
Create the string object with the received size rather than overwriting the last byte with nul. This fixes the bug where it was required to send a trailing '\n' to have the json properly decoded.